### PR TITLE
Add run_and_handle_error to check for expected errors

### DIFF
--- a/step_exec_lib/utils/processes.py
+++ b/step_exec_lib/utils/processes.py
@@ -16,7 +16,7 @@ def run_and_log(args: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
     return run_res
 
 
-def run_and_handle_error(args: List[str], error_text: str, **kwargs: Any) -> int:
+def run_and_handle_error(args: List[str], expected_error_text: str, **kwargs: Any) -> int:
     logger.info("Running command:")
     logger.info(" ".join(args))
     if "text" not in kwargs:
@@ -30,9 +30,9 @@ def run_and_handle_error(args: List[str], error_text: str, **kwargs: Any) -> int
     except subprocess.CalledProcessError as e:
         logger.info(f"CalledProcessError: {e}.")
 
-        if error_text in e.stderr:
-            logger.info(f"Found expected error text '{error_text}', exit code: 0")
+        if expected_error_text in e.stderr:
+            logger.info(f"Found expected error text '{expected_error_text}', exit code: 0")
             return 0
         else:
-            logger.info(f"Did not find error text '{error_text}', exit code: 1")
-            return 1
+            logger.info(f"Did not find error text '{expected_error_text}', exit code: {run_res.returncode}")
+            return run_res.returncode

--- a/step_exec_lib/utils/processes.py
+++ b/step_exec_lib/utils/processes.py
@@ -10,6 +10,29 @@ def run_and_log(args: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
     logger.info(" ".join(args))
     if "text" not in kwargs:
         kwargs["text"] = True
+
     run_res = subprocess.run(args, **kwargs)  # nosec
     logger.info(f"Command executed, exit code: {run_res.returncode}.")
     return run_res
+
+
+def run_and_handle_error(args: List[str], error_text: str, **kwargs: Any) -> int:
+    logger.info("Running command:")
+    logger.info(" ".join(args))
+    if "text" not in kwargs:
+        kwargs["text"] = True
+
+    try:
+        run_res = subprocess.run(args, **kwargs, check=True, stderr=subprocess.PIPE)  # nosec
+        logger.info(f"Command executed, exit code: {run_res.returncode}.")
+        return run_res.returncode
+
+    except subprocess.CalledProcessError as e:
+        logger.info(f"CalledProcessError: {e}.")
+
+        if error_text in e.stderr:
+            logger.info(f"Found expected error text '{error_text}', exit code: 0")
+            return 0
+        else:
+            logger.info(f"Did not find error text '{error_text}', exit code: 1")
+            return 1


### PR DESCRIPTION
Towards giantswarm/giantswarm#18384

Adds a new `run_and_handle_error` function that checks if an error occurs and returns exit code 0.
This is to avoid complicating the existing `run_and_log` function.

It's needed because `go test` returns an error if no go files match the build tag specified.

```
go test -v -tags=functional ./integration/test/metrics
package github.com/giantswarm/app-test-suite/integration/test/metrics: build constraints exclude all Go files in /Users/rossf7/src/giantswarm/app-test-suite/integration/test/metrics
```

