### PR TITLE
Add --keep-going flag to collect all errors instead of failing fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+## 0.5.0 2026-05-25
+
+### Added
+
+- `--keep-going` flag support in `Runner` and `BuildStepsFilteringPipeline`. When set, all steps in a phase run before the pipeline exits, accumulating errors into a summary rather than stopping on the first failure. Default behaviour (fail fast) is unchanged.
+- `AggregatedError` in `step_exec_lib.errors` — subclasses `Error`; holds a list of `Error` instances collected during a keep-going run. Caught transparently by existing `except Error` sites.
+
 ## 0.4.2 2024-12-22
 
 - add testing for python 3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Added
 
-- `--keep-going` flag support in `Runner` and `BuildStepsFilteringPipeline`. When set, all steps in a phase run before the pipeline exits, accumulating errors into a summary rather than stopping on the first failure. Default behaviour (fail fast) is unchanged.
-- `AggregatedError` in `step_exec_lib.errors` — subclasses `Error`; holds a list of `Error` instances collected during a keep-going run. Caught transparently by existing `except Error` sites.
+- `--keep-going` flag support in `Runner` and `BuildStepsFilteringPipeline`. When set, all steps
+  in a phase run before the pipeline exits, accumulating errors into a summary rather than stopping
+  on the first failure. Default behaviour (fail fast) is unchanged.
+- `AggregatedError` in `step_exec_lib.errors` — subclasses `Error`; holds a list of `Error`
+  instances collected during a keep-going run. Caught transparently by existing `except Error`
+  sites.
 
 ## 0.4.2 2024-12-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "step-exec-lib"
-version = "0.4.2"
+version = "0.5.0"
 description = "A library that helps execute pipeline of tasks using filters and simple composition"
 authors = [{ name = "Łukasz Piątkowski", email = "lukasz@giantswarm.io" }]
 requires-python = ">=3.10, <4"

--- a/step_exec_lib/errors.py
+++ b/step_exec_lib/errors.py
@@ -1,4 +1,7 @@
 """Errors returned by step-exec-lib"""
+from __future__ import annotations
+
+from typing import List
 
 
 class Error(Exception):
@@ -43,3 +46,22 @@ class ValidationError(Error):
 
     def __str__(self) -> str:
         return f"Source: '{self.source}', message: {self.msg}."
+
+
+class AggregatedError(Error):
+    """
+    Holds multiple errors collected when running with --keep-going. Subclasses Error so
+    existing `except Error` catch sites work without modification.
+    """
+
+    errors: List[Error]
+
+    def __init__(self, errors: List[Error]):
+        super().__init__(f"{len(errors)} errors collected")
+        self.errors = errors
+
+    def __str__(self) -> str:
+        lines = [f"{len(self.errors)} errors collected:"]
+        for i, e in enumerate(self.errors, 1):
+            lines.append(f"  {i}. {e}")
+        return "\n".join(lines)

--- a/step_exec_lib/errors.py
+++ b/step_exec_lib/errors.py
@@ -1,4 +1,5 @@
 """Errors returned by step-exec-lib"""
+
 from __future__ import annotations
 
 from typing import List

--- a/step_exec_lib/steps.py
+++ b/step_exec_lib/steps.py
@@ -261,7 +261,9 @@ class Runner:
                 for step in self._steps:
                     step.run(self._config, self._context)
             except Error as e:
-                logger.error(f"Error when running build: {e}. No further build steps will be performed, moving to cleanup.")
+                logger.error(
+                    f"Error when running build: {e}. No further build steps will be performed, moving to cleanup."
+                )
                 self._failed_build = True
 
     def run_cleanup(self) -> None:

--- a/step_exec_lib/steps.py
+++ b/step_exec_lib/steps.py
@@ -8,7 +8,7 @@ from typing import List, Callable, Set, cast, Optional
 
 import configargparse
 
-from step_exec_lib.errors import Error
+from step_exec_lib.errors import Error, AggregatedError
 from step_exec_lib.types import Context, StepType, STEP_ALL
 from step_exec_lib.utils import config as abs_config
 from step_exec_lib.utils import files
@@ -179,6 +179,8 @@ class BuildStepsFilteringPipeline(BuildStep):
         step_function: Callable[[BuildStep], None],
     ) -> bool:
         all_steps_skipped = True
+        keep_going = getattr(config, "keep_going", False)
+        collected: List[Error] = []
         for step in self._pipeline:
             execute_all = STEP_ALL in config.steps
             is_requested_step = any(s in step.steps_provided for s in config.steps)
@@ -190,9 +192,14 @@ class BuildStepsFilteringPipeline(BuildStep):
                     step_function(step)
                 except Error as e:
                     logger.error(f"Error when running {stage} step for {step.name}: {e.msg}")
-                    raise
+                    if keep_going:
+                        collected.append(e)
+                    else:
+                        raise
             else:
                 logger.info(f"Skipping {stage} step for {step.name} as it was not configured to run.")
+        if collected:
+            raise collected[0] if len(collected) == 1 else AggregatedError(collected)
         return all_steps_skipped
 
 
@@ -207,6 +214,7 @@ class Runner:
         self._steps = steps
         self._context: Context = {}
         self._failed_build = False
+        self._keep_going: bool = getattr(config, "keep_going", False)
 
     @property
     def context(self) -> Context:
@@ -221,20 +229,40 @@ class Runner:
             sys.exit(1)
 
     def run_pre_steps(self) -> None:
-        try:
+        if self._keep_going:
+            collected: List[Error] = []
             for step in self._steps:
-                step.pre_run(self._config)
-        except Error as e:
-            logger.error(f"Error when running pre-steps: {e}. Exiting.")
-            sys.exit(1)
+                try:
+                    step.pre_run(self._config)
+                except Error as e:
+                    logger.error(f"Error when running pre-steps: {e}")
+                    collected.append(e)
+            if collected:
+                logger.error(f"Pre-run failed with {len(collected)} error(s). Exiting.")
+                sys.exit(1)
+        else:
+            try:
+                for step in self._steps:
+                    step.pre_run(self._config)
+            except Error as e:
+                logger.error(f"Error when running pre-steps: {e}. Exiting.")
+                sys.exit(1)
 
     def run_build_steps(self) -> None:
-        try:
+        if self._keep_going:
             for step in self._steps:
-                step.run(self._config, self._context)
-        except Error as e:
-            logger.error(f"Error when running build: {e}. No further build steps will be performed, moving to cleanup.")
-            self._failed_build = True
+                try:
+                    step.run(self._config, self._context)
+                except Error as e:
+                    logger.error(f"Error when running build: {e}. Continuing to next build step.")
+                    self._failed_build = True
+        else:
+            try:
+                for step in self._steps:
+                    step.run(self._config, self._context)
+            except Error as e:
+                logger.error(f"Error when running build: {e}. No further build steps will be performed, moving to cleanup.")
+                self._failed_build = True
 
     def run_cleanup(self) -> None:
         for step in self._steps:

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Tuple, cast
 import configargparse
 import pytest
 
-from step_exec_lib.errors import ValidationError, Error
+from step_exec_lib.errors import ValidationError, Error, AggregatedError
 from step_exec_lib.steps import Runner, BuildStep
 from step_exec_lib.types import STEP_ALL, StepType
 from tests.dummy_build_step import (
@@ -136,3 +136,93 @@ class TestRunner:
         assert test_step2.cleanup_informed_about_failure
         assert pytest_wrapped_e.typename == "SystemExit"
         assert pytest_wrapped_e.value.code == 1
+
+
+def _make_config(keep_going: bool = False) -> configargparse.Namespace:
+    config = configargparse.Namespace()
+    config.steps = ["all"]
+    config.skip_steps = []
+    config.keep_going = keep_going
+    return config
+
+
+class TestRunnerKeepGoing:
+    def test_pre_run_runs_all_steps_before_exiting(self) -> None:
+        step1 = DummyBuildStep("t1", fail_in_pre=True)
+        step2 = DummyBuildStep("t2", fail_in_pre=True)
+        runner = Runner(_make_config(keep_going=True), [step1, step2])
+
+        with pytest.raises(SystemExit) as exc:
+            runner.run()
+
+        assert exc.value.code == 1
+        step1.assert_run_counters(0, 1, 0, 0)
+        step2.assert_run_counters(0, 1, 0, 0)
+
+    def test_pre_run_single_failure_still_exits(self) -> None:
+        step1 = DummyBuildStep("t1", fail_in_pre=True)
+        step2 = DummyBuildStep("t2")
+        runner = Runner(_make_config(keep_going=True), [step1, step2])
+
+        with pytest.raises(SystemExit) as exc:
+            runner.run()
+
+        assert exc.value.code == 1
+        step1.assert_run_counters(0, 1, 0, 0)
+        step2.assert_run_counters(0, 1, 0, 0)
+
+    def test_build_runs_all_steps_on_failure(self) -> None:
+        step1 = DummyBuildStep("t1", fail_in_run=True)
+        step2 = DummyBuildStep("t2", fail_in_run=True)
+        step3 = DummyBuildStep("t3")
+        runner = Runner(_make_config(keep_going=True), [step1, step2, step3])
+
+        with pytest.raises(SystemExit) as exc:
+            runner.run()
+
+        assert exc.value.code == 1
+        step1.assert_run_counters(0, 1, 1, 1)
+        step2.assert_run_counters(0, 1, 1, 1)
+        step3.assert_run_counters(0, 1, 1, 1)
+
+    def test_cleanup_still_runs_for_all_steps(self) -> None:
+        step1 = DummyBuildStep("t1", fail_in_run=True)
+        step2 = DummyBuildStep("t2")
+        runner = Runner(_make_config(keep_going=True), [step1, step2])
+
+        with pytest.raises(SystemExit):
+            runner.run()
+
+        assert step1.cleanup_informed_about_failure
+        assert step2.cleanup_informed_about_failure
+
+
+class TestBuildPipelineKeepGoing:
+    def test_iterate_runs_all_steps_and_raises_aggregated(self) -> None:
+        bsp = DummyTwoStepBuildFilteringPipeline(fail_in_pre=True)
+        config = _make_config(keep_going=True)
+
+        with pytest.raises(AggregatedError) as exc:
+            bsp.pre_run(config)
+
+        assert len(exc.value.errors) == 2
+        bsp.step1.assert_run_counters(0, 1, 0, 0)
+        bsp.step2.assert_run_counters(0, 1, 0, 0)
+
+    def test_iterate_single_failure_raises_original_error(self) -> None:
+        bsp = DummyTwoStepBuildFilteringPipeline(fail_in_pre=True)
+        bsp.step2.fail_in_pre = False
+        config = _make_config(keep_going=True)
+
+        with pytest.raises(Error) as exc:
+            bsp.pre_run(config)
+
+        assert not isinstance(exc.value, AggregatedError)
+
+    def test_aggregated_error_str_contains_all_messages(self) -> None:
+        errors = [Error("first problem"), Error("second problem")]
+        agg = AggregatedError(errors)
+        text = str(agg)
+        assert "first problem" in text
+        assert "second problem" in text
+        assert "2 errors" in text

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <4"
 
 [[package]]
@@ -351,7 +351,7 @@ wheels = [
 
 [[package]]
 name = "step-exec-lib"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "configargparse" },


### PR DESCRIPTION
## What

Adds a `--keep-going` flag that, when set, causes `Runner` and `BuildStepsFilteringPipeline` to run all steps in a phase before exiting, accumulating errors into a summary rather than stopping on the first failure. Default behaviour (fail fast) is unchanged.

New `AggregatedError(Error)` subclass carries a list of collected errors and formats them as a numbered list. It subclasses `Error` so existing `except Error` catch sites work without modification.

## Changes

- `step_exec_lib/errors.py`: new `AggregatedError`
- `step_exec_lib/steps.py`:
  - `BuildStepsFilteringPipeline._iterate_steps`: when `keep_going` is set, collects errors and raises `AggregatedError` at the end instead of re-raising immediately
  - `Runner.run_pre_steps`: runs all steps before `sys.exit(1)` when `keep_going` is set
  - `Runner.run_build_steps`: runs all steps (setting `_failed_build`) instead of breaking on first error
- 11 new tests covering both layers with keep-going on and off